### PR TITLE
Proposal for fixing mid-sim storage issue.

### DIFF
--- a/pysim/commonsystem.pyx
+++ b/pysim/commonsystem.pyx
@@ -111,7 +111,7 @@ cdef class Results:
             bs = bytes(name,'utf-8')
             size = self.shp.getStoreSize()
             columns = self.shp.getStoreColumns(bs)
-            a_mat = np.zeros([size,columns],dtype=np.float64)
+            a_mat = np.ones([size,columns],dtype=np.float64)*np.nan
             self.shp.fillWithStore(bs,&a_mat[0,0],size,columns)
             if columns == 1:
                 return a_mat[:,0]

--- a/pysim/cppsource/StoreHandler.cpp
+++ b/pysim/cppsource/StoreHandler.cpp
@@ -132,27 +132,29 @@ void StoreHandler::fillWithStore(char* name, double* p, int rows, int columns) {
         if (columns != 1) {
             throw std::runtime_error("Internal Pysim Error, invalid number of columns");
         }
+		ptemp += rows;
         auto v = &(d_ptr->storemap[name]->storearray);
         int rowcounter = 0;
-        for (auto i = v->cbegin(); i != v->cend(); ++i) {
+        for (auto i = v->rbegin(); i != v->rend(); ++i) {
             if (++rowcounter > rows) {
                 throw std::runtime_error("Internal Pysim Error, invalid number of rows");
             }
-            *(ptemp++) = *i;
+            *(--ptemp) = *i;
         }
     } else if (d_ptr->storeVectorMap.count(name) > 0) {
+		ptemp += rows*columns;
         auto mat = &(d_ptr->storeVectorMap[name]->storearray);
         int rowcounter = 0;
-        for (auto row = mat->cbegin(); row != mat->cend(); ++row) {
+        for (auto row = mat->rbegin(); row != mat->rend(); ++row) {
             if (++rowcounter > rows) {
                 throw std::runtime_error("Internal Pysim Error, invalid number of rows");
             }
             int columncounter = 0;
-            for (auto i = row->begin(); i != row->end(); ++i) {
+            for (auto i = row->rbegin(); i != row->rend(); ++i) {
                 if (++columncounter > columns) {
                     throw std::runtime_error("Internal Pysim Error, invalid number of columns");
                 }
-                *(ptemp++) = *i;
+                *(--ptemp) = *i;
             }
         }
     }

--- a/pysim/tests/store_test.py
+++ b/pysim/tests/store_test.py
@@ -130,3 +130,21 @@ def test_interval_store(test_class):
     reftime = np.linspace(0,2,11)
     simtime = sys.res.time
     assert np.all(np.abs(simtime-reftime) <= np.finfo(float).eps)
+	
+@pytest.mark.parametrize("test_class",[VanDerPol,PythonVanDerPol])
+def test_midsim_store(test_class):
+    """Check that it is possible to store a variable mid-simulation
+    and that the result array is properly aligned with the timesteps
+    and contains np.nan for locations where the variable was not stored.
+    """
+    sim = Sim()
+    sys = test_class()
+    
+    sim.add_system(sys)
+    sim.simulate(5, 1)
+    sys.store("a")
+    sim.simulate(5, 1)
+    ares = sys.res.a
+    assert np.all(np.isnan(ares[:6]))
+    assert not np.any(np.isnan(ares[6:]))
+


### PR DESCRIPTION
Filling store arrays from end to beginning instead of from beginning to end. This works since stored variable cannot be "unstored". 

Also, non-stored timesteps default to np.nan, numpys implementation of nan. Not sure about this.
Fixes #14 