### PR TITLE
Check NaN

### DIFF
--- a/pysim/cppsource/ConnectionHandler.cpp
+++ b/pysim/cppsource/ConnectionHandler.cpp
@@ -154,18 +154,33 @@ void ConnectionHandler::connect(char* outputname, T* inputsys, char* inputname, 
 template void ConnectionHandler::connect<CommonSystemImpl>(char* outputname, CommonSystemImpl* inputsys, char* inputname, int output_index);
 template void ConnectionHandler::connect<CompositeSystemImpl>(char* outputname, CompositeSystemImpl* inputsys, char* inputname, int output_index);
 
+template<typename T>
+void check_copy(T vi){
+    *(vi.second) = *(vi.first);
+}
+
 void ConnectionHandler::copyoutputs() {
-    auto copyfunc = [] (auto vi){*(vi.second) = *(vi.first);};
-    for_each(d_ptr->connected_scalars.cbegin(),d_ptr->connected_scalars.cend(),copyfunc);
-    for_each(d_ptr->connected_vectors.cbegin(),d_ptr->connected_vectors.cend(),copyfunc);
-    for_each(d_ptr->connected_matrices.cbegin(),d_ptr->connected_matrices.cend(),copyfunc);
+    for( auto connection: d_ptr->connected_scalars){
+        check_copy(connection);
+    }
+    for( auto connection: d_ptr->connected_vectors){
+        check_copy(connection);
+    }
+    for( auto connection: d_ptr->connected_matrices){
+        check_copy(connection);
+    }
 }
 
 void ConnectionHandler::copystateoutputs() {
-    auto copyfunc = [] (auto vi){*(vi.second) = *(vi.first);};
-    for_each(d_ptr->connected_scalar_states_.cbegin(),d_ptr->connected_scalar_states_.cend(),copyfunc);
-    for_each(d_ptr->connected_vector_states.cbegin(),d_ptr->connected_vector_states.cend(),copyfunc);
-    for_each(d_ptr->connected_matrix_states.cbegin(),d_ptr->connected_matrix_states.cend(),copyfunc);
+    for( auto connection: d_ptr->connected_scalar_states_){
+        check_copy(connection);
+    }
+    for( auto connection: d_ptr->connected_vector_states){
+        check_copy(connection);
+    }
+    for( auto connection: d_ptr->connected_matrix_states){
+        check_copy(connection);
+    }
 }
 
 

--- a/pysim/cppsource/ConnectionHandler.cpp
+++ b/pysim/cppsource/ConnectionHandler.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 #include <string>
 
-
 #include <Eigen/Dense>
 
 #include "CommonSystemImpl_p.hpp"
@@ -154,8 +153,21 @@ void ConnectionHandler::connect(char* outputname, T* inputsys, char* inputname, 
 template void ConnectionHandler::connect<CommonSystemImpl>(char* outputname, CommonSystemImpl* inputsys, char* inputname, int output_index);
 template void ConnectionHandler::connect<CompositeSystemImpl>(char* outputname, CompositeSystemImpl* inputsys, char* inputname, int output_index);
 
-template<typename T>
-void check_copy(T vi){
+void check_copy(std::pair<double *,double *> vi){
+    if (isnan(*(vi.first))){
+        throw std::runtime_error("Output from system is NaN");
+    }
+    *(vi.second) = *(vi.first);
+}
+
+void copy(std::pair<pysim::vector *,pysim::vector *> vi){
+    *(vi.second) = *(vi.first);
+}
+
+void check_copy(std::pair<Eigen::MatrixXd *,Eigen::MatrixXd *> vi){
+    if (vi.first->hasNaN()){
+        throw std::runtime_error("Output from system is NaN");
+    }
     *(vi.second) = *(vi.first);
 }
 
@@ -164,7 +176,7 @@ void ConnectionHandler::copyoutputs() {
         check_copy(connection);
     }
     for( auto connection: d_ptr->connected_vectors){
-        check_copy(connection);
+        copy(connection);
     }
     for( auto connection: d_ptr->connected_matrices){
         check_copy(connection);
@@ -176,7 +188,7 @@ void ConnectionHandler::copystateoutputs() {
         check_copy(connection);
     }
     for( auto connection: d_ptr->connected_vector_states){
-        check_copy(connection);
+        copy(connection);
     }
     for( auto connection: d_ptr->connected_matrix_states){
         check_copy(connection);

--- a/pysim/cppsource/ConnectionHandler.cpp
+++ b/pysim/cppsource/ConnectionHandler.cpp
@@ -154,7 +154,7 @@ template void ConnectionHandler::connect<CommonSystemImpl>(char* outputname, Com
 template void ConnectionHandler::connect<CompositeSystemImpl>(char* outputname, CompositeSystemImpl* inputsys, char* inputname, int output_index);
 
 void check_copy(std::pair<double *,double *> vi){
-    if (isnan(*(vi.first))){
+    if (std::isnan(*(vi.first))){
         throw std::runtime_error("Output from system is NaN");
     }
     *(vi.second) = *(vi.first);

--- a/pysim/tests/input_ouput_test.py
+++ b/pysim/tests/input_ouput_test.py
@@ -316,6 +316,48 @@ def test_vector_scalar_conn(sys1_class,sys2_class):
     assert sys2.outputs.input_output_scalar == 2.0
     assert sys3.outputs.input_output_scalar == 5.0
 
+@pytest.mark.parametrize("sys1_class,sys2_class",
+                         [(InOutTestSystem,InOutTestSystem),
+                          (PythonInOutTestSystem,PythonInOutTestSystem),
+                          (InOutTestSystem,PythonInOutTestSystem),
+                          (PythonInOutTestSystem,InOutTestSystem),
+                         ])
+def test_nan_connection_scalar(sys1_class,sys2_class):
+    """Check that an exception is thrown if a scalar NaN is being copied to another system.
+    """
+    sys1 = sys1_class()
+    sys2 = sys2_class()
+
+    sys1.inputs.input_scalar = float('nan')
+    sys1.connections.add_connection("input_output_scalar",sys2,"input_scalar")
+
+    sim = Sim()
+    sim.add_system(sys1)
+    sim.add_system(sys2)
+    with pytest.raises(RuntimeError):
+        sim.simulate(0.1,0.1)
+
+@pytest.mark.parametrize("sys1_class,sys2_class",
+                         [(InOutTestSystem,InOutTestSystem),
+                          (PythonInOutTestSystem,PythonInOutTestSystem),
+                          (InOutTestSystem,PythonInOutTestSystem),
+                          (PythonInOutTestSystem,InOutTestSystem),
+                         ])
+def test_nan_connection_matrix(sys1_class,sys2_class):
+    """Check that an exception is thrown if a scalar NaN is being copied to another system.
+    """
+    sys1 = sys1_class()
+    sys2 = sys2_class()
+
+    sys1.inputs.input_matrix= [[float('nan'),0,0],[0,0,0],[0,0,0]]
+    sys1.connections.add_connection("input_output_matrix",sys2,"input_matrix")
+
+    sim = Sim()
+    sim.add_system(sys1)
+    sim.add_system(sys2)
+    with pytest.raises(RuntimeError):
+        sim.simulate(0.1,0.1)
+
 def test_der_as_output():
     """Test that it is possible to connect a derivative as output
     


### PR DESCRIPTION
Functionality for checking if a NaN is being copied from one system to another. If so a RunTime exception will be thrown. This currently works for scalars and matrices. Since the boost vectors are depreciated it will not be implemented for them.

Fixes #8 
