### PR TITLE
Run GitHub Actions on current versions of Python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,7 +33,8 @@ jobs:
       - name: Install Python dependencies
         run: | 
           pip install wheel
-          pip install -r ./requirements.txt 'setuptools;python_version >= "3.12"'
+          # Use setuptools<60.0 until aldebjer/pysim#45 is fixed.
+          pip install -r ./requirements.txt setuptools<60.0
 
       - name: Install C++ dependencies on macOS and build
         if: runner.os == 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,6 +17,7 @@ jobs:
   build:
     runs-on: ${{matrix.os}}
     strategy:
+      fail-fast: false
       matrix:  # https://github.com/actions/python-versions/releases
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: ['macos-latest', 'ubuntu-latest', 'windows-latest']
@@ -32,7 +33,7 @@ jobs:
       - name: Install Python dependencies
         run: | 
           pip install wheel
-          pip install -r ./requirements.txt
+          pip install -r ./requirements.txt 'setuptools;python_version >= "3.12"'
 
       - name: Install C++ dependencies on macOS and build
         if: runner.os == 'macOS'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,7 @@ jobs:
         run: | 
           pip install wheel
           # Use setuptools<60.0 until aldebjer/pysim#45 is fixed.
-          pip install -r ./requirements.txt setuptools<60.0
+          pip install -r ./requirements.txt 'setuptools<60.0'
 
       - name: Install C++ dependencies on macOS and build
         if: runner.os == 'macOS'


### PR DESCRIPTION
Bundled `setuptools` removed in Python 3.12
* python/cpython#95299

Blocked by:
* #45
* #46